### PR TITLE
Add Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.git
+npm-debug.log
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use Node LTS version with smaller footprint
+FROM node:18-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY package.json package-lock.json ./
+RUN npm install -g expo-cli && npm install
+
+# Copy project files
+COPY . .
+
+# Expose the default Expo port
+EXPOSE 8081
+
+# Start the Expo development server
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
 # RNdeliverable
+
+This is a small React Native project using Expo. The application can be run locally or inside a Docker container.
+
+## Requirements
+- Node.js 18
+- npm
+
+## Running Locally
+Install dependencies and start the Expo development server:
+
+```bash
+npm install
+npm start
+```
+
+## Docker
+A `Dockerfile` is provided to containerize the project.
+
+### Build the image
+```bash
+docker build -t rndeliverable .
+```
+
+### Run the container
+```bash
+docker run -p 8081:8081 rndeliverable
+```
+
+The Expo server will start inside the container and can be accessed on port `8081`.


### PR DESCRIPTION
## Summary
- add Dockerfile to run the expo app
- ignore build artifacts in `.dockerignore`
- document Docker usage and update project README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6852f66f7c98832eb6143ff0735f5493