### PR TITLE
Enable navigation across screens

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,27 +2,14 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 
-import DashboardScreen from './Screen/DashboardScreen';
-import LeaderboardScreen from './Screen/LeaderboardScreen';
-import TasksScreen from './Screen/TasksScreen';
-import RewardsScreen from './Screen/RewardsScreen';
-
-// 想看哪个就把这个值改成 'Dashboard' | 'Leaderboard' | 'Tasks' | 'Rewards'
-const WHICH = 'Rewards';
-
-const SCREENS = {
-  Dashboard: DashboardScreen,
-  Leaderboard: LeaderboardScreen,
-  Tasks: TasksScreen,
-  Rewards: RewardsScreen,
-};
+// The navigation stack/tabs are defined in `navigation/AppNavigator`
+import AppNavigator from './navigation/AppNavigator';
 
 export default function App() {
-  const Current = SCREENS[WHICH] || DashboardScreen;
-  // 不需要导航也能看页面；如果你页面里用到了 navigation，就包个容器：
+  // Render the full navigator so the app can switch between screens
   return (
     <NavigationContainer>
-      <Current />
+      <AppNavigator />
     </NavigationContainer>
   );
 }

--- a/navigation/AppNavigator.js
+++ b/navigation/AppNavigator.js
@@ -4,10 +4,12 @@ import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
 
-import DashboardScreen from '../screens/DashboardScreen';
-import LeaderboardScreen from '../screens/LeaderboardScreen';
-import TasksScreen from '../screens/TasksScreen';
-import RewardsScreen from '../screens/RewardsScreen';
+// The screen components live in the `Screen` directory (capital S)
+// rather than `screens`, adjust the import paths accordingly.
+import DashboardScreen from '../Screen/DashboardScreen';
+import LeaderboardScreen from '../Screen/LeaderboardScreen';
+import TasksScreen from '../Screen/TasksScreen';
+import RewardsScreen from '../Screen/RewardsScreen';
 
 const Tab = createBottomTabNavigator();
 const Stack = createNativeStackNavigator();


### PR DESCRIPTION
## Summary
- fix navigation imports
- switch App to use the configured navigator

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68878bcfae58832eac622155ba055ea6