### PR TITLE
Add global points context and link tasks to leaderboard

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,6 +1,7 @@
 // App.js
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
+import { PointsProvider } from './context/PointsContext';
 
 // The navigation stack/tabs are defined in `navigation/AppNavigator`
 import AppNavigator from './navigation/AppNavigator';
@@ -8,8 +9,10 @@ import AppNavigator from './navigation/AppNavigator';
 export default function App() {
   // Render the full navigator so the app can switch between screens
   return (
-    <NavigationContainer>
-      <AppNavigator />
-    </NavigationContainer>
+    <PointsProvider>
+      <NavigationContainer>
+        <AppNavigator />
+      </NavigationContainer>
+    </PointsProvider>
   );
 }

--- a/Screen/LeaderboardScreen.js
+++ b/Screen/LeaderboardScreen.js
@@ -1,5 +1,5 @@
 // LeaderboardScreen.js
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import {
   View,
   Text,
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { currentUser, leaderboardUsers } from '../constants/mockUsers';
+import { PointsContext } from '../context/PointsContext';
 
 // 阶段 0、1 用同一张图片；阶段 2 用满分图片
 const CARD_IMAGES = [
@@ -26,9 +27,8 @@ const DEFAULT_AVATAR = require('../assets/Lead/Head.png');
 const COMMUNITY_ICON = require('../assets/Lead/map-pin.png');
 
 export default function LeaderboardScreen() {
-  // 任务进度 0 -> 1 -> 2（满）
-  const [taskProgress, setTaskProgress] = useState(0);
-  const [points, setPoints] = useState(currentUser.dailyPoints);
+  // 来自全局上下文的积分与任务进度
+  const { points, taskProgress } = useContext(PointsContext);
   const [cardH, setCardH] = useState(0); // 记录卡片实际高度以定位按钮
   const navigation = useNavigation();
 
@@ -38,13 +38,6 @@ export default function LeaderboardScreen() {
   const isFull = taskProgress >= 2;
 
   const onPressComplete = () => {
-    if (!isFull) {
-      setTaskProgress((p) => {
-        const next = Math.min(p + 1, 2);
-        setPoints((v) => v + 50);
-        return next;
-      });
-    }
     navigation.navigate('Tasks');
   };
 

--- a/Screen/RewardsScreen.js
+++ b/Screen/RewardsScreen.js
@@ -1,5 +1,5 @@
 // RewardsScreen.js
-import React, { useState } from 'react';
+import React, { useContext } from 'react';
 import {
   View,
   Text,
@@ -10,13 +10,14 @@ import {
 } from 'react-native';
 import RewardCard from '../components/RewardCard';
 import { rewardItems } from '../constants/mockRewards';
+import { PointsContext } from '../context/PointsContext';
 
 const RewardsScreen = () => {
-  const [points, setPoints] = useState(500); // 可用积分（不再单独显示）
+  const { points, deductPoints } = useContext(PointsContext);
 
   const handleExchange = (item) => {
     if (points >= item.costPoints) {
-      setPoints((p) => p - item.costPoints);
+      deductPoints(item.costPoints);
       Alert.alert('Success', `You have redeemed: ${item.name}`);
     } else {
       Alert.alert('Not Enough Points', 'You do not have enough points to redeem this item.');

--- a/Screen/TasksScreen.js
+++ b/Screen/TasksScreen.js
@@ -1,5 +1,5 @@
 // TasksScreen.js
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import {
   View,
   Text,
@@ -11,15 +11,24 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { taskList } from '../constants/mockTasks';
 import TaskCard from '../components/TaskCard';
+import { PointsContext } from '../context/PointsContext';
 
 export default function TasksScreen() {
   const navigation = useNavigation();
   const [tasks, setTasks] = useState(taskList);
+  const { addPoints, incrementProgress } = useContext(PointsContext);
 
   // 按“索引”完成，避免重复 id 影响到多条
   const handleCompleteAt = (index) => {
     setTasks((prev) =>
-      prev.map((t, i) => (i === index ? { ...t, completed: true } : t))
+      prev.map((t, i) => {
+        if (i === index && !t.completed) {
+          addPoints(t.points || 0);
+          incrementProgress();
+          return { ...t, completed: true };
+        }
+        return t;
+      })
     );
   };
 

--- a/context/PointsContext.js
+++ b/context/PointsContext.js
@@ -1,0 +1,28 @@
+import React, { createContext, useState } from 'react';
+import { currentUser } from '../constants/mockUsers';
+
+export const PointsContext = createContext({
+  points: 0,
+  addPoints: () => {},
+  deductPoints: () => {},
+  taskProgress: 0,
+  incrementProgress: () => {},
+});
+
+export const PointsProvider = ({ children }) => {
+  const [points, setPoints] = useState(currentUser.dailyPoints || 0);
+  const [taskProgress, setTaskProgress] = useState(0);
+
+  const addPoints = (p = 0) => setPoints((v) => v + p);
+  const deductPoints = (p = 0) => setPoints((v) => Math.max(0, v - p));
+  const incrementProgress = () =>
+    setTaskProgress((p) => Math.min(p + 1, 2));
+
+  return (
+    <PointsContext.Provider
+      value={{ points, addPoints, deductPoints, taskProgress, incrementProgress }}
+    >
+      {children}
+    </PointsContext.Provider>
+  );
+};


### PR DESCRIPTION
## Summary
- introduce `PointsContext` to manage points and task progress globally
- wrap navigator in `PointsProvider`
- show and update points from context on leaderboard
- award points from the Task screen
- deduct points in Rewards screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688880d2ddec832ea776cd9ce4151452