### PR TITLE
Implement reward exchange point check

### DIFF
--- a/Screen/RewardsScreen.js
+++ b/Screen/RewardsScreen.js
@@ -17,10 +17,16 @@ const RewardsScreen = () => {
 
   const handleExchange = (item) => {
     if (points >= item.costPoints) {
+      // Sufficient points: deduct and show success message
+      const remaining = points - item.costPoints;
       deductPoints(item.costPoints);
-      Alert.alert('Success', `You have redeemed: ${item.name}`);
+      Alert.alert(
+        'Success',
+        `Successfully redeemed ${item.name}! You have ${remaining} points left.`
+      );
     } else {
-      Alert.alert('Not Enough Points', 'You do not have enough points to redeem this item.');
+      // Insufficient points warning
+      Alert.alert('Insufficient Points', 'You do not have enough points to redeem this reward.');
     }
   };
 

--- a/components/RewardCard.js
+++ b/components/RewardCard.js
@@ -13,7 +13,7 @@ const RewardCard = ({ item, onExchange }) => {
         }
       </View>
       <Text style={styles.name} numberOfLines={1} ellipsizeMode="tail">{item.name}</Text>
-      <Text style={styles.cost}>{item.costPoints} 积分</Text>
+      <Text style={styles.cost}>{item.costPoints} points</Text>
       <TouchableOpacity style={styles.button} onPress={onExchange}>
         <Text style={styles.buttonText}>Exchange</Text>
       </TouchableOpacity>


### PR DESCRIPTION
## Summary
- adjust `RewardsScreen` point exchange logic
- show remaining points in success message
- keep reward card text in English

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888869de024832ea0c3f847e1605912