### PR TITLE
Fix missing screens and icon paths

### DIFF
--- a/Screen/TaskDetailScreen.js
+++ b/Screen/TaskDetailScreen.js
@@ -1,0 +1,63 @@
+import React, { useContext } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useRoute, useNavigation } from '@react-navigation/native';
+import { PointsContext } from '../context/PointsContext';
+
+export default function TaskDetailScreen() {
+  const route = useRoute();
+  const navigation = useNavigation();
+  const { addPoints, incrementProgress } = useContext(PointsContext);
+
+  const task = route.params?.task || {};
+  const title = task.title || 'Task Detail';
+  const description = task.description || '';
+  const points = task.points || 0;
+
+  const onComplete = () => {
+    addPoints(points);
+    incrementProgress();
+    navigation.replace('TaskSuccess', { points });
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+      {!!description && <Text style={styles.description}>{description}</Text>}
+      <TouchableOpacity style={styles.button} onPress={onComplete}>
+        <Text style={styles.buttonText}>Complete Task</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    color: '#111',
+  },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 20,
+    color: '#374151',
+  },
+  button: {
+    backgroundColor: '#22c55e',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+});

--- a/Screen/TaskDetailScreen.js
+++ b/Screen/TaskDetailScreen.js
@@ -9,11 +9,13 @@ export default function TaskDetailScreen() {
   const { addPoints, incrementProgress } = useContext(PointsContext);
 
   const task = route.params?.task || {};
+  const markComplete = route.params?.onComplete;
   const title = task.title || 'Task Detail';
   const description = task.description || '';
   const points = task.points || 0;
 
   const onComplete = () => {
+    markComplete?.();
     addPoints(points);
     incrementProgress();
     navigation.replace('TaskSuccess', { points });

--- a/Screen/TaskSuccessScreen.js
+++ b/Screen/TaskSuccessScreen.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useRoute, useNavigation } from '@react-navigation/native';
+
+export default function TaskSuccessScreen() {
+  const navigation = useNavigation();
+  const route = useRoute();
+  const points = route.params?.points ?? 0;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Task Completed!</Text>
+      {points ? <Text style={styles.points}>+{points} pts</Text> : null}
+      <TouchableOpacity
+        style={styles.button}
+        onPress={() => navigation.navigate('Leaderboard')}
+      >
+        <Text style={styles.buttonText}>Back to Leaderboard</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 10,
+    color: '#111',
+  },
+  points: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#22c55e',
+    marginBottom: 20,
+  },
+  button: {
+    backgroundColor: '#22c55e',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 8,
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+});

--- a/Screen/TasksScreen.js
+++ b/Screen/TasksScreen.js
@@ -32,6 +32,13 @@ export default function TasksScreen() {
     );
   };
 
+  const handlePressTask = (task, index) => {
+    navigation.navigate('TaskDetail', {
+      task,
+      onComplete: () => handleCompleteAt(index),
+    });
+  };
+
   // 过滤掉 undefined / null / 非对象
   const safeTasks = Array.isArray(tasks)
     ? tasks.filter((t) => t && typeof t === 'object')
@@ -69,6 +76,7 @@ export default function TasksScreen() {
               key={task.id ?? `idx-${index}`}
               task={task}
               onComplete={() => handleCompleteAt(index)}
+              onPress={() => handlePressTask(task, index)}
               containerStyle={styles.cardSpacing}
               glass={true}
             />

--- a/app.json
+++ b/app.json
@@ -4,11 +4,11 @@
     "slug": "snack-c031519f-1445-4bb3-a343-eacd9bcdd072",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/icon.png",
+    "icon": "./assets/images/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,
     "splash": {
-      "image": "./assets/splash-icon.png",
+      "image": "./assets/images/splash-screen.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
@@ -17,13 +17,13 @@
     },
     "android": {
       "adaptiveIcon": {
-        "foregroundImage": "./assets/adaptive-icon.png",
+        "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
       "edgeToEdgeEnabled": true
     },
     "web": {
-      "favicon": "./assets/favicon.png"
+      "favicon": "./assets/images/favicon.png"
     }
   }
 }

--- a/components/TaskCard.js
+++ b/components/TaskCard.js
@@ -8,10 +8,11 @@ import { BlurView } from 'expo-blur';
 const DEFAULT_ICON = require('../assets/Lead/card1.png');
 
 export default function TaskCard({
-  task = {},              // 防止 undefined
+  task = {}, // 防止 undefined
   onComplete,
+  onPress,
   containerStyle,
-  glass = true,           // 是否启用毛玻璃
+  glass = true, // 是否启用毛玻璃
 }) {
   // 字段
   const title = task.title ?? task.name ?? task.heading ?? 'Task';
@@ -34,8 +35,14 @@ export default function TaskCard({
       <View style={styles.plain}>{children}</View>
     );
 
+  const Wrapper = onPress ? TouchableOpacity : View;
+
   return (
-    <View style={[styles.cardWrapper, containerStyle]}>
+    <Wrapper
+      style={[styles.cardWrapper, containerStyle]}
+      onPress={onPress}
+      activeOpacity={0.9}
+    >
       <CardShell>
         <View style={styles.row}>
           {/* 左侧图标 */}
@@ -71,7 +78,7 @@ export default function TaskCard({
           </View>
         </View>
       </CardShell>
-    </View>
+    </Wrapper>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "RNdeliverable-codex-modify-complete-task-button-behavior",
+  "name": "RNdeliverable",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary
- implement `TaskDetailScreen` logic for completing tasks
- implement `TaskSuccessScreen` with simple UI
- correct asset paths in `app.json`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68889bf4c488832eac45f6f5ff5ee8a3