### PR TITLE
Add web alerts and english text for points

### DIFF
--- a/Screen/RewardsScreen.js
+++ b/Screen/RewardsScreen.js
@@ -7,6 +7,7 @@ import {
   FlatList,
   Alert,
   ImageBackground,
+  Platform,
 } from 'react-native';
 import RewardCard from '../components/RewardCard';
 import { rewardItems } from '../constants/mockRewards';
@@ -18,9 +19,19 @@ const RewardsScreen = () => {
   const handleExchange = (item) => {
     if (points >= item.costPoints) {
       deductPoints(item.costPoints);
-      Alert.alert('Success', `You have redeemed: ${item.name}`);
+      const msg = `You have redeemed: ${item.name}`;
+      if (Platform.OS === 'web') {
+        window.alert(`Success\n${msg}`);
+      } else {
+        Alert.alert('Success', msg);
+      }
     } else {
-      Alert.alert('Not Enough Points', 'You do not have enough points to redeem this item.');
+      const err = 'You do not have enough points to redeem this item.';
+      if (Platform.OS === 'web') {
+        window.alert(`Not Enough Points\n${err}`);
+      } else {
+        Alert.alert('Not Enough Points', err);
+      }
     }
   };
 

--- a/components/RewardCard.js
+++ b/components/RewardCard.js
@@ -13,7 +13,7 @@ const RewardCard = ({ item, onExchange }) => {
         }
       </View>
       <Text style={styles.name} numberOfLines={1} ellipsizeMode="tail">{item.name}</Text>
-      <Text style={styles.cost}>{item.costPoints} 积分</Text>
+      <Text style={styles.cost}>{item.costPoints} point</Text>
       <TouchableOpacity style={styles.button} onPress={onExchange}>
         <Text style={styles.buttonText}>Exchange</Text>
       </TouchableOpacity>


### PR DESCRIPTION
## Summary
- show redemption result using `alert` on web
- display item cost in English

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68893a7cba14832e82170227ade1f8f7