### PR TITLE
Add responsive web styles and blur fallbacks

### DIFF
--- a/Screen/DashboardScreen.js
+++ b/Screen/DashboardScreen.js
@@ -23,6 +23,7 @@ export default function DashboardScreen() {
   const [mode, setMode] = useState('home');    // 'home' 或 'community'
   const [stats, setStats] = useState(null);
   const animated = useRef(new Animated.Value(0)).current;
+  const isWeb = Platform.OS === 'web';
 
 const currentUserId = 1; // TODO: 替换为真实用户 ID
 
@@ -43,8 +44,30 @@ useEffect(() => {
     outputRange: ['180deg', '360deg'],
   });
 
+  const FrontCard = isWeb ? View : Animated.View;
+  const BackCard = isWeb ? View : Animated.View;
+
+  const BlurWrapper = ({ children }) =>
+    isWeb ? (
+      <View style={[styles.pillBlur, styles.webBlur]}>{children}</View>
+    ) : (
+      <BlurView
+        style={styles.pillBlur}
+        intensity={80}
+        tint="light"
+        experimentalBlurMethod={Platform.OS === 'android' ? 'dimezisBlurView' : 'none'}
+        blurReductionFactor={4}
+      >
+        {children}
+      </BlurView>
+    );
+
   // 执行动画并切换模式
   const flipCard = () => {
+    if (isWeb) {
+      setMode(prev => (prev === 'home' ? 'community' : 'home'));
+      return;
+    }
     Animated.spring(animated, {
       toValue: mode === 'home' ? 180 : 0,
       friction: 8,
@@ -58,7 +81,7 @@ useEffect(() => {
   return (
     <ImageBackground
       source={require('../assets/HomeScreen/bg.png')}
-      style={styles.screenBg}
+      style={[styles.screenBg, isWeb && styles.screenBgWeb]}
       imageStyle={styles.screenBgImage}
     >
       <View style={styles.container}>
@@ -74,11 +97,11 @@ useEffect(() => {
       {/* 翻转卡片 */}
       <View style={styles.cardWrapper}>
         {/* 我的家（正面） */}
-        <Animated.View
+        <FrontCard
           style={[
             styles.innerCard,
-            { transform: [{ rotateY: frontInterpol }] },
-            mode === 'community' && { opacity: 0 }
+            !isWeb && { transform: [{ rotateY: frontInterpol }] },
+            mode === 'community' && { opacity: 0, display: isWeb ? 'none' : 'flex' }
           ]}
         >
           <ImageBackground
@@ -92,13 +115,7 @@ useEffect(() => {
             </Pressable>
             <View style={styles.statRow}>
               <View style={styles.pillBox}>
-                <BlurView
-                  style={styles.pillBlur}
-                  intensity={80}
-                  tint="light"
-                  experimentalBlurMethod={Platform.OS === 'android' ? 'dimezisBlurView' : 'none'}
-                  blurReductionFactor={4}
-                >
+                <BlurWrapper>
                   <View style={styles.pillHeaderRow}>
                     <Image source={require('../assets/HomeScreen/lightning.png')} style={styles.pillIcon} />
                   </View>
@@ -107,16 +124,10 @@ useEffect(() => {
                     <Text style={styles.unitText}> kWh</Text>
                   </View>
                   <Text style={styles.pillCaption}>Used</Text>
-                </BlurView>
+                </BlurWrapper>
               </View>
               <View style={styles.pillBox}>
-                <BlurView
-                  style={styles.pillBlur}
-                  intensity={80}
-                  tint="light"
-                  experimentalBlurMethod={Platform.OS === 'android' ? 'dimezisBlurView' : 'none'}
-                  blurReductionFactor={4}
-                >
+                <BlurWrapper>
                   <View style={styles.pillHeaderRow}>
                     <Image source={require('../assets/HomeScreen/star.png')} style={styles.pillIcon} />
                   </View>
@@ -125,18 +136,18 @@ useEffect(() => {
                     <Text style={styles.unitText}> pts</Text>
                   </View>
                   <Text style={styles.pillCaption}>Earned</Text>
-                </BlurView>
+                </BlurWrapper>
               </View>
             </View>
           </ImageBackground>
-        </Animated.View>
+        </FrontCard>
 
         {/* 社区（背面） */}
-        <Animated.View
+        <BackCard
           style={[
             styles.innerCard,
-            { transform: [{ rotateY: backInterpol }] },
-            mode === 'home' && { opacity: 0 }
+            !isWeb && { transform: [{ rotateY: backInterpol }] },
+            mode === 'home' && { opacity: 0, display: isWeb ? 'none' : 'flex' }
           ]}
         >
           <ImageBackground
@@ -150,13 +161,7 @@ useEffect(() => {
             </Pressable>
             <View style={styles.statRow}>
               <View style={styles.pillBox}>
-                <BlurView
-                  style={styles.pillBlur}
-                  intensity={80}
-                  tint="light"
-                  experimentalBlurMethod={Platform.OS === 'android' ? 'dimezisBlurView' : 'none'}
-                  blurReductionFactor={4}
-                >
+                <BlurWrapper>
                   <View style={styles.pillHeaderRow}>
                     <Image source={require('../assets/HomeScreen/lightning.png')} style={styles.pillIcon} />
                   </View>
@@ -165,16 +170,10 @@ useEffect(() => {
                     <Text style={styles.unitText}> kWh</Text>
                   </View>
                   <Text style={styles.pillCaption}>Used</Text>
-                </BlurView>
+                </BlurWrapper>
               </View>
               <View style={styles.pillBox}>
-                <BlurView
-                  style={styles.pillBlur}
-                  intensity={80}
-                  tint="light"
-                  experimentalBlurMethod={Platform.OS === 'android' ? 'dimezisBlurView' : 'none'}
-                  blurReductionFactor={4}
-                >
+                <BlurWrapper>
                   <View style={styles.pillHeaderRow}>
                     <Image source={require('../assets/HomeScreen/star.png')} style={styles.pillIcon} />
                   </View>
@@ -183,11 +182,11 @@ useEffect(() => {
                     <Text style={styles.unitText}> pts</Text>
                   </View>
                   <Text style={styles.pillCaption}>Earned</Text>
-                </BlurView>
+                </BlurWrapper>
               </View>
             </View>
           </ImageBackground>
-        </Animated.View>
+        </BackCard>
       </View>
 
       {/* 挑战入口 */}
@@ -224,8 +223,14 @@ useEffect(() => {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 16, backgroundColor: 'transparent' },
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: 'transparent',
+    ...(Platform.OS === 'web' && { width: '100%', maxWidth: 480, alignSelf: 'center' }),
+  },
   screenBg: { flex: 1 },
+  screenBgWeb: { width: '100%', height: '100%' },
   screenBgImage: { resizeMode: 'cover' },
   header: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
   location: { fontSize: 14 },
@@ -301,6 +306,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 16,
     justifyContent: 'center',
+  },
+  webBlur: {
+    backgroundColor: 'rgba(255,255,255,0.6)',
   },
   pillHeaderRow: {
     height: 28,

--- a/Screen/LeaderboardScreen.js
+++ b/Screen/LeaderboardScreen.js
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   ScrollView,
+  Platform,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { currentUser, leaderboardUsers } from '../constants/mockUsers';
@@ -55,7 +56,7 @@ export default function LeaderboardScreen() {
   return (
     <ImageBackground
       source={require('../assets/Lead/bg.png')}
-      style={styles.screenBg}
+      style={[styles.screenBg, Platform.OS === 'web' && styles.screenBgWeb]}
       imageStyle={styles.screenBgImage}
     >
       <ScrollView style={styles.container} contentContainerStyle={styles.content}>
@@ -176,11 +177,13 @@ const CARD_HEIGHT = 100; // 你的设计卡片高度；需要更高就调这里
 
 const styles = StyleSheet.create({
   screenBg: { flex: 1 },
+  screenBgWeb: { width: '100%', height: '100%' },
   screenBgImage: { resizeMode: 'cover' },
 
   container: {
     flex: 1,
     backgroundColor: 'transparent',
+    ...(Platform.OS === 'web' && { width: '100%', maxWidth: 480, alignSelf: 'center' }),
   },
   content: {
     padding: 20,

--- a/Screen/RewardsScreen.js
+++ b/Screen/RewardsScreen.js
@@ -7,27 +7,39 @@ import {
   FlatList,
   Alert,
   ImageBackground,
+  Platform,
 } from 'react-native';
 import RewardCard from '../components/RewardCard';
 import { rewardItems } from '../constants/mockRewards';
 import { PointsContext } from '../context/PointsContext';
 
 const RewardsScreen = () => {
+  const isWeb = Platform.OS === 'web';
   const { points, deductPoints } = useContext(PointsContext);
 
   const handleExchange = (item) => {
     if (points >= item.costPoints) {
       deductPoints(item.costPoints);
-      Alert.alert('Success', `You have redeemed: ${item.name}`);
+      const msg = `You have redeemed: ${item.name}`;
+      if (Platform.OS === 'web') {
+        window.alert(`Success\n${msg}`);
+      } else {
+        Alert.alert('Success', msg);
+      }
     } else {
-      Alert.alert('Not Enough Points', 'You do not have enough points to redeem this item.');
+      const err = 'You do not have enough points to redeem this item.';
+      if (Platform.OS === 'web') {
+        window.alert(`Not Enough Points\n${err}`);
+      } else {
+        Alert.alert('Not Enough Points', err);
+      }
     }
   };
 
   return (
     <ImageBackground
       source={require('../assets/Lead/bg.png')}
-      style={styles.bg}
+      style={[styles.bg, isWeb && styles.bgWeb]}
       imageStyle={styles.bgImg}
     >
       <View style={styles.container}>
@@ -51,12 +63,18 @@ const RewardsScreen = () => {
 
 const styles = StyleSheet.create({
   bg: { flex: 1 },
+  bgWeb: { width: '100%', height: '100%' },
   bgImg: { resizeMode: 'cover' },
 
   container: {
     flex: 1,
     backgroundColor: 'transparent',
     paddingTop: 40,
+    ...(Platform.OS === 'web' && {
+      width: '100%',
+      maxWidth: 480,
+      alignSelf: 'center',
+    }),
   },
   header: {
     fontSize: 24,

--- a/Screen/TasksScreen.js
+++ b/Screen/TasksScreen.js
@@ -7,6 +7,7 @@ import {
   ScrollView,
   StyleSheet,
   ImageBackground,
+  Platform,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import { taskList } from '../constants/mockTasks';
@@ -43,7 +44,7 @@ export default function TasksScreen() {
   return (
     <ImageBackground
       source={require('../assets/Lead/bg.png')}
-      style={styles.screenBg}
+      style={[styles.screenBg, Platform.OS === 'web' && styles.screenBgWeb]}
       imageStyle={styles.screenBgImage}
     >
       <View style={styles.screen}>
@@ -84,11 +85,13 @@ export default function TasksScreen() {
 
 const styles = StyleSheet.create({
   screenBg: { flex: 1 },
+  screenBgWeb: { width: '100%', height: '100%' },
   screenBgImage: { resizeMode: 'cover' },
 
   screen: {
     flex: 1,
     backgroundColor: 'transparent',
+    ...(Platform.OS === 'web' && { width: '100%', maxWidth: 480, alignSelf: 'center' }),
   },
 
   /* header */
@@ -128,6 +131,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingHorizontal: 16,
+    ...(Platform.OS === 'web' && { width: '100%', maxWidth: 480, alignSelf: 'center' }),
   },
 
   cardSpacing: {

--- a/components/RewardCard.js
+++ b/components/RewardCard.js
@@ -13,7 +13,7 @@ const RewardCard = ({ item, onExchange }) => {
         }
       </View>
       <Text style={styles.name} numberOfLines={1} ellipsizeMode="tail">{item.name}</Text>
-      <Text style={styles.cost}>{item.costPoints} 积分</Text>
+      <Text style={styles.cost}>{item.costPoints} point</Text>
       <TouchableOpacity style={styles.button} onPress={onExchange}>
         <Text style={styles.buttonText}>Exchange</Text>
       </TouchableOpacity>

--- a/components/TaskCard.js
+++ b/components/TaskCard.js
@@ -1,6 +1,6 @@
 // components/TaskCard.js
 import React from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Image } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Image, Platform } from 'react-native';
 import { BlurView } from 'expo-blur';
 
 // 占位图（可换成你的）
@@ -13,6 +13,7 @@ export default function TaskCard({
   containerStyle,
   glass = true,           // 是否启用毛玻璃
 }) {
+  const isWeb = Platform.OS === 'web';
   // 字段
   const title = task.title ?? task.name ?? task.heading ?? 'Task';
   const description = task.description ?? task.desc ?? task.subtitle ?? '';
@@ -26,12 +27,12 @@ export default function TaskCard({
       : task.icon || DEFAULT_ICON;
 
   const CardShell = ({ children }) =>
-    glass ? (
+    glass && !isWeb ? (
       <BlurView intensity={35} tint="light" style={styles.blur}>
         <View style={styles.glassOverlay}>{children}</View>
       </BlurView>
     ) : (
-      <View style={styles.plain}>{children}</View>
+      <View style={[styles.plain, glass && styles.glassOverlay]}>{children}</View>
     );
 
   return (
@@ -104,6 +105,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#fff',
     borderRadius: RADIUS,
     padding: 12,
+    width: '100%',
   },
 
   row: {


### PR DESCRIPTION
## Summary
- adjust background images and container widths when running on web
- degrade blur effects and card flip animation for browsers
- show redemption results with alerts on web and keep English "point" text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68893a7cba14832e82170227ade1f8f7